### PR TITLE
ci: Sync Pull Request Labels

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,5 +1,7 @@
 files:
   - README.md
   - LICENSE
+excludedFiles:
+  - CHANGELOG.md
 aliveStatusCodes:
   - 200

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,4 +1,3 @@
-
 # Default GitHub labels
 - color: d73a4a
   name: bug
@@ -32,19 +31,19 @@
   description: The issue is expected and will not be fixed
 # Release Please
 - color: ededed
-  name: 'autorelease: pending'
+  name: "autorelease: pending"
   description:
 - color: ededed
-  name: 'autorelease: tagged'
+  name: "autorelease: tagged"
   description:
 - color: ededed
-  name: 'autorelease: triggered'
+  name: "autorelease: triggered"
   description:
 - color: ededed
-  name: 'autorelease: snapshot'
+  name: "autorelease: snapshot"
   description:
 - color: ededed
-  name: 'autorelease: published'
+  name: "autorelease: published"
   description:
 # Languages
 - color: 2b67c6
@@ -53,4 +52,3 @@
 - color: 000000
   name: github_actions
   description: Pull requests that update GitHub Actions code
-

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,0 +1,32 @@
+
+# Default GitHub labels
+- color: c13253
+  name: bug
+  description: Functionality that does not work as intended/expected
+- color: 18377f
+  name: documentation
+  description:
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: d23a4a
+  name: automation
+  description: Changes done to the .github folder
+- color: blocked
+  name: ed848a
+  description: The issue is blocked by another issue that has to be resolved first
+- color: cccccc
+  name: duplicate
+  description: This issue or pull request already exists
+- color: 84b6eb
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: bbf796
+  name: good first issue
+  description: Good for newcomers
+- color: f9bbc0
+  name: help wanted
+  description: We are looking for community help
+- color: ffffff
+  name: wontfix
+  description: The issue is expected and will not be fixed

--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,32 +1,56 @@
 
 # Default GitHub labels
-- color: c13253
+- color: d73a4a
   name: bug
-  description: Functionality that does not work as intended/expected
-- color: 18377f
+  description: Something isn't working
+- color: 0075ca
   name: documentation
   description:
 - color: 0366d6
   name: dependencies
   description: Pull requests that update a dependency file
-- color: d23a4a
-  name: automation
-  description: Changes done to the .github folder
-- color: blocked
-  name: ed848a
-  description: The issue is blocked by another issue that has to be resolved first
-- color: cccccc
+- color: cfd3d7
   name: duplicate
   description: This issue or pull request already exists
-- color: 84b6eb
+- color: a2eeef
   name: enhancement
   description: Functionality that enhances existing features
-- color: bbf796
+- color: 7057ff
   name: good first issue
   description: Good for newcomers
-- color: f9bbc0
+- color: 008672
   name: help wanted
   description: We are looking for community help
-- color: ffffff
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
   name: wontfix
   description: The issue is expected and will not be fixed
+# Release Please
+- color: ededed
+  name: 'autorelease: pending'
+  description:
+- color: ededed
+  name: 'autorelease: tagged'
+  description:
+- color: ededed
+  name: 'autorelease: triggered'
+  description:
+- color: ededed
+  name: 'autorelease: snapshot'
+  description:
+- color: ededed
+  name: 'autorelease: published'
+  description:
+# Languages
+- color: 2b67c6
+  name: python
+  description: Pull requests that update Python code
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: Sync labels
+name: "Sync labels"
 
 on:
   push:
@@ -6,17 +6,10 @@ on:
       - main
     paths:
       - .github/other-configurations/labels.yml
-    pull_request:
-      types:
-        - opened
-        - synchronize
-        - reopened
-        - labeled
-        - unlabeled
+
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,7 +6,13 @@ on:
       - main
     paths:
       - .github/other-configurations/labels.yml
-
+    pull_request:
+      types:
+        - opened
+        - synchronize
+        - reopened
+        - labeled
+        - unlabeled
 jobs:
   configure-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - .github/other-configurations/labels.yml
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   configure-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,23 @@
+name: Sync labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml


### PR DESCRIPTION
Add a workflow to sync labels that can be used by #46 to label pull requests.

fixes #47 