### PR TITLE
ci: Fix Markdown Link Check on CHANGELOG.md

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,5 +1,6 @@
 dirs:
   - ./
-
+excludedFiles:
+  - ./CHANGELOG.md
 aliveStatusCodes:
   - 200

--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,7 +1,6 @@
-files:
-  - README.md
-  - LICENSE
+dirs:
+  - ./
 excludedFiles:
-  - CHANGELOG.md
+  - ./CHANGELOG.md
 aliveStatusCodes:
   - 200

--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,6 +1,5 @@
 dirs:
   - ./
-excludedFiles:
-  - ./CHANGELOG.md
+
 aliveStatusCodes:
   - 200

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -85,7 +85,7 @@ jobs:
         uses: UmbrellaDocs/action-linkspector@v1.1.3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configurations/.linkspector.yaml
+          config_file: .github/other-configurations/.linkspector.yml
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.2.0](https://github.com/JackPlowman/github-stats/compare/v0.1.0...v0.2.0) (2024-08-28)
+
+
+### 🚀 Features
+
+* Assign files without extensions to languages ([#44](https://github.com/JackPlowman/github-stats/issues/44)) ([1225277](https://github.com/JackPlowman/github-stats/commit/1225277c7bb1b8318c9f679d59ead1e2523deb44)), closes [#35](https://github.com/JackPlowman/github-stats/issues/35)
+* Count number of files in repository ([#37](https://github.com/JackPlowman/github-stats/issues/37)) ([00d2579](https://github.com/JackPlowman/github-stats/commit/00d257948489147a1cc5a8af6bfd98feb9e044cc)), closes [#39](https://github.com/JackPlowman/github-stats/issues/39)
+* Generate Total Identified Files Per Repository ([#63](https://github.com/JackPlowman/github-stats/issues/63)) ([7aa37a6](https://github.com/JackPlowman/github-stats/commit/7aa37a615ae960974fbf766d8e151943d200c817))
+* Link Summary Table to Repository Page ([#65](https://github.com/JackPlowman/github-stats/issues/65)) ([8402629](https://github.com/JackPlowman/github-stats/commit/840262933b6a65f225c2b9f298027845869d03a5)), closes [#67](https://github.com/JackPlowman/github-stats/issues/67)
+* Prioritise Popular Languages When Multiple Languages Detected ([#62](https://github.com/JackPlowman/github-stats/issues/62)) ([e6b7e82](https://github.com/JackPlowman/github-stats/commit/e6b7e82ec2fe378a1023df8ea412c22b58f2694d)), closes [#60](https://github.com/JackPlowman/github-stats/issues/60)
+
+
+### 🐛 Bugfixes
+
+* Update Pull Request Checks Workflow Triggers ([#66](https://github.com/JackPlowman/github-stats/issues/66)) ([2308cdb](https://github.com/JackPlowman/github-stats/commit/2308cdb120490f5c612e835d5200b88b535df3be)), closes [#68](https://github.com/JackPlowman/github-stats/issues/68)
+
+
+### ⬆️ Dependency updates
+
+* **github-actions:** Bump actions/labeler from 4 to 5 ([#53](https://github.com/JackPlowman/github-stats/issues/53)) ([1b360ca](https://github.com/JackPlowman/github-stats/commit/1b360ca7b7c3f8ca7ad065f922e560eadf588b5d)), closes [#54](https://github.com/JackPlowman/github-stats/issues/54)
+
+
+### 🧰 Maintenance
+
+* Add Issue Templates ([#59](https://github.com/JackPlowman/github-stats/issues/59)) ([a9fc52f](https://github.com/JackPlowman/github-stats/commit/a9fc52fe11b8caeeff424ec44a6aa0dd70664371)), closes [#58](https://github.com/JackPlowman/github-stats/issues/58)
+* Add Pull Request Template ([#57](https://github.com/JackPlowman/github-stats/issues/57)) ([306e0b8](https://github.com/JackPlowman/github-stats/commit/306e0b8af79eb95c3067500b06baf65b7f0b5703)), closes [#56](https://github.com/JackPlowman/github-stats/issues/56)
+* Add Python Debug Launch Configuration ([#61](https://github.com/JackPlowman/github-stats/issues/61)) ([1a2f5b6](https://github.com/JackPlowman/github-stats/commit/1a2f5b63dfc96e7e7c71f8232a3fe23fc5085890))
+* Add Workflow to Check Pull Request Title ([#45](https://github.com/JackPlowman/github-stats/issues/45)) ([22774a6](https://github.com/JackPlowman/github-stats/commit/22774a6e6f0a3553ad92f6d5642add8d9e4d6e5c)), closes [#41](https://github.com/JackPlowman/github-stats/issues/41)
+* Pull Request Labels ([#49](https://github.com/JackPlowman/github-stats/issues/49)) ([79f61cf](https://github.com/JackPlowman/github-stats/commit/79f61cfe2620c28ac0e9041c40fac80980ec50ff)), closes [#46](https://github.com/JackPlowman/github-stats/issues/46)
+* Run Linkspector On All Files ([#70](https://github.com/JackPlowman/github-stats/issues/70)) ([2ceeea1](https://github.com/JackPlowman/github-stats/commit/2ceeea1921464eade3435136324ed1e425eb555d))
+* Sync Pull Request Labels ([#48](https://github.com/JackPlowman/github-stats/issues/48)) ([d284bf9](https://github.com/JackPlowman/github-stats/commit/d284bf98a5ce297c25cd8f3952809c7ac4cbdc5f)), closes [#47](https://github.com/JackPlowman/github-stats/issues/47)
+* Update labels ([#55](https://github.com/JackPlowman/github-stats/issues/55)) ([3006076](https://github.com/JackPlowman/github-stats/commit/30060761d9d70aecd51cbe47f87cfed4233c17a1))
+
 ## 0.1.0 (2024-08-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,5 @@
 # Changelog
 
-## [0.2.0](https://github.com/JackPlowman/github-stats/compare/v0.1.0...v0.2.0) (2024-08-28)
-
-
-### 🚀 Features
-
-* Assign files without extensions to languages ([#44](https://github.com/JackPlowman/github-stats/issues/44)) ([1225277](https://github.com/JackPlowman/github-stats/commit/1225277c7bb1b8318c9f679d59ead1e2523deb44)), closes [#35](https://github.com/JackPlowman/github-stats/issues/35)
-* Count number of files in repository ([#37](https://github.com/JackPlowman/github-stats/issues/37)) ([00d2579](https://github.com/JackPlowman/github-stats/commit/00d257948489147a1cc5a8af6bfd98feb9e044cc)), closes [#39](https://github.com/JackPlowman/github-stats/issues/39)
-* Generate Total Identified Files Per Repository ([#63](https://github.com/JackPlowman/github-stats/issues/63)) ([7aa37a6](https://github.com/JackPlowman/github-stats/commit/7aa37a615ae960974fbf766d8e151943d200c817))
-* Link Summary Table to Repository Page ([#65](https://github.com/JackPlowman/github-stats/issues/65)) ([8402629](https://github.com/JackPlowman/github-stats/commit/840262933b6a65f225c2b9f298027845869d03a5)), closes [#67](https://github.com/JackPlowman/github-stats/issues/67)
-* Prioritise Popular Languages When Multiple Languages Detected ([#62](https://github.com/JackPlowman/github-stats/issues/62)) ([e6b7e82](https://github.com/JackPlowman/github-stats/commit/e6b7e82ec2fe378a1023df8ea412c22b58f2694d)), closes [#60](https://github.com/JackPlowman/github-stats/issues/60)
-
-
-### 🐛 Bugfixes
-
-* Update Pull Request Checks Workflow Triggers ([#66](https://github.com/JackPlowman/github-stats/issues/66)) ([2308cdb](https://github.com/JackPlowman/github-stats/commit/2308cdb120490f5c612e835d5200b88b535df3be)), closes [#68](https://github.com/JackPlowman/github-stats/issues/68)
-
-
-### ⬆️ Dependency updates
-
-* **github-actions:** Bump actions/labeler from 4 to 5 ([#53](https://github.com/JackPlowman/github-stats/issues/53)) ([1b360ca](https://github.com/JackPlowman/github-stats/commit/1b360ca7b7c3f8ca7ad065f922e560eadf588b5d)), closes [#54](https://github.com/JackPlowman/github-stats/issues/54)
-
-
-### 🧰 Maintenance
-
-* Add Issue Templates ([#59](https://github.com/JackPlowman/github-stats/issues/59)) ([a9fc52f](https://github.com/JackPlowman/github-stats/commit/a9fc52fe11b8caeeff424ec44a6aa0dd70664371)), closes [#58](https://github.com/JackPlowman/github-stats/issues/58)
-* Add Pull Request Template ([#57](https://github.com/JackPlowman/github-stats/issues/57)) ([306e0b8](https://github.com/JackPlowman/github-stats/commit/306e0b8af79eb95c3067500b06baf65b7f0b5703)), closes [#56](https://github.com/JackPlowman/github-stats/issues/56)
-* Add Python Debug Launch Configuration ([#61](https://github.com/JackPlowman/github-stats/issues/61)) ([1a2f5b6](https://github.com/JackPlowman/github-stats/commit/1a2f5b63dfc96e7e7c71f8232a3fe23fc5085890))
-* Add Workflow to Check Pull Request Title ([#45](https://github.com/JackPlowman/github-stats/issues/45)) ([22774a6](https://github.com/JackPlowman/github-stats/commit/22774a6e6f0a3553ad92f6d5642add8d9e4d6e5c)), closes [#41](https://github.com/JackPlowman/github-stats/issues/41)
-* Pull Request Labels ([#49](https://github.com/JackPlowman/github-stats/issues/49)) ([79f61cf](https://github.com/JackPlowman/github-stats/commit/79f61cfe2620c28ac0e9041c40fac80980ec50ff)), closes [#46](https://github.com/JackPlowman/github-stats/issues/46)
-* Run Linkspector On All Files ([#70](https://github.com/JackPlowman/github-stats/issues/70)) ([2ceeea1](https://github.com/JackPlowman/github-stats/commit/2ceeea1921464eade3435136324ed1e425eb555d))
-* Sync Pull Request Labels ([#48](https://github.com/JackPlowman/github-stats/issues/48)) ([d284bf9](https://github.com/JackPlowman/github-stats/commit/d284bf98a5ce297c25cd8f3952809c7ac4cbdc5f)), closes [#47](https://github.com/JackPlowman/github-stats/issues/47)
-* Update labels ([#55](https://github.com/JackPlowman/github-stats/issues/55)) ([3006076](https://github.com/JackPlowman/github-stats/commit/30060761d9d70aecd51cbe47f87cfed4233c17a1))
-
 ## 0.1.0 (2024-08-26)
 
 


### PR DESCRIPTION
# Pull Request

## Description

Fix Linkspector checking markdown links in CHANGELOG.md as comparison doesn't yet exist.

fixes #69
