### PR TITLE
chore: Disable SuperLinter TypeScript Linting and Formatting

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Lint and Format everything but Python/Typescript
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.1.0
         env:
@@ -36,6 +37,9 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_RUFF: false
           VALIDATE_PYTHON_PYINK: false
+          VALIDATE_TYPESCRIPT_ES: false
+          VALIDATE_TYPESCRIPT_PRETTIER: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
 
   check-python-code-format-and-quality:
     name: Check Python Code Format and Quality


### PR DESCRIPTION
# Pull Request

## Description

Disable SuperLinter from formatting and linting TypeScript
