### PR TITLE
fix!: Fix GitHub Pages Link

### DIFF
--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -1,4 +1,4 @@
 <meta
   http-equiv="refresh"
-  content="0; url=https://jackplowman.github.io/github-stats/generated_markdown/index.html"
+  content="0; url=https://jackplowman.github.io/github-stats-prototype/generated_markdown/index.html"
 />


### PR DESCRIPTION
# Pull Request

## Description

Fix GitHub pages redirect link from `https://jackplowman.github.io/github-stats/generated_markdown/index.html` to `https://jackplowman.github.io/github-stats-prototype/generated_markdown/index.html"`