### PR TITLE
chore: Add size labels to GitHub configuration

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -59,3 +59,22 @@
 - color: 0E8A16
   name: tests
   description: Pull requests that update tests
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request


### PR DESCRIPTION
# Pull Request

## Description

This change adds new labels to categorise pull requests by size. The following size labels have been introduced:

- size/XS: Extra Small Pull Request
- size/S: Small Pull Request
- size/M: Medium Pull Request
- size/L: Large Pull Request
- size/XL: Extra Large Pull Request
- size/XXL: Extra Extra Large Pull Request

Each size label is assigned a unique colour, ranging from green for smaller PRs to dark red for the largest ones. This addition will help in quickly identifying the scope and complexity of pull requests, facilitating more efficient review processes and workload management.

fixes #161