### PR TITLE
chore: Update VS Code settings for Ruff and file nesting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "ruff.configuration": "analyser/pyproject.toml",
   "python.testing.cwd": "${workspaceFolder}/analyser",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
@@ -7,5 +8,11 @@
     ".pytest_cache": true,
     "**/.ruff_cache": true,
     "**/.pytest_cache": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pyproject.toml": "__init__.py, poetry.lock, coverage.xml, .coverage, .gitignore",
+    "package.json": "package-lock.json, eslint.config.js, astro.config.mjs, .prettierrc.mjs, .gitignore"
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

This change updates the VS Code settings to enhance the development environment:

1. Adds Ruff configuration path, pointing to the analyser's pyproject.toml file.

2. Enables file nesting in the Explorer view, with specific patterns for:
   - pyproject.toml: Nesting related Python project files
   - package.json: Nesting related JavaScript/Node.js project files

3. Sets the file nesting to be collapsed by default.

These changes aim to improve code organisation and streamline the project structure within VS Code.

fixes #170